### PR TITLE
Upgrade Alpine rootfs branch From 3.10 to 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This [image][233] serves as the base rootfs container for [Alpine Linux][131].
 Built from scratch using the minirootfs image from [here][132].
 
-Current minirootfs version: `3.10.1`.  
+Current minirootfs version: `3.12.4`.  
 [ Older versions can be found in ARCH_VERSION tags e.g ...:x86_64_3.9.4, ...:x86_64_3.10.0 ]
 
 The image is tagged respectively for the following architectures,

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ OPSYS     := alpine
 SHCOMMAND := /bin/bash
 SVCNAME   := base
 USERNAME  := woahbase
-OSVERSION := 3.10.1
+OSVERSION := 3.12.4
 
 DOCKERSRC := scratch
 DOCKEREPO := $(OPSYS)-$(SVCNAME)


### PR DESCRIPTION
- v3.10 branch is about to get EOL status in about a month.
- As it's not 2019 anymore, and new releases include bug fixes,
  all distributions should be updated to at least v3.12.4 branch.

Signed-off-by: rokibhasansagar <rokibhasansagar2014@outlook.com>